### PR TITLE
Add WebGUI static knowledge layer (7 new MCP tools)

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -77,6 +77,16 @@ class Settings(BaseSettings):
         description="Path to the YAML file defining documentation sources",
     )
 
+    # WebGUI Knowledge Layer Configuration
+    webgui_schema_file: Path = Field(
+        default=Path("data/schemas/crawl-31e23c1bfdd1.json"),
+        description="Path to the WebGUI crawl schema JSON file",
+    )
+    webgui_screenshots_dir: Path = Field(
+        default=Path("data/crawl-31e23c1bfdd1"),
+        description="Directory containing WebGUI page screenshots",
+    )
+
     @property
     def api_base_url(self) -> str:
         """Get API base URL as string."""

--- a/src/server.py
+++ b/src/server.py
@@ -2,6 +2,7 @@
 
 import logging
 import asyncio
+from pathlib import Path
 from typing import Any, List
 
 from mcp.server.models import InitializationOptions
@@ -237,6 +238,13 @@ from .knowledge.tools.management import (
 )
 from .knowledge.tools.management import configure as configure_management
 
+# WebGUI Knowledge Layer tools
+from .webgui.tools import (
+    WEBGUI_TOOL_DEFINITIONS,
+    WEBGUI_HANDLERS,
+)
+from .webgui.tools import configure as configure_webgui
+
 # Get settings
 _settings = get_settings()
 
@@ -350,6 +358,8 @@ def _build_registry():
         (KNOWLEDGE_SEARCH_TOOL_DEFINITIONS, KNOWLEDGE_SEARCH_HANDLERS),
         (KNOWLEDGE_RETRIEVAL_TOOL_DEFINITIONS, KNOWLEDGE_RETRIEVAL_HANDLERS),
         (KNOWLEDGE_MANAGEMENT_TOOL_DEFINITIONS, KNOWLEDGE_MANAGEMENT_HANDLERS),
+        # WebGUI Knowledge Layer tools
+        (WEBGUI_TOOL_DEFINITIONS, WEBGUI_HANDLERS),
     ]:
         for name, defn_func in defn_dict.items():
             tool = defn_func()
@@ -383,6 +393,21 @@ class FortiMonitorMCPServer:
             sources_file=kb_sources,
             embedding_model=kb_model,
         )
+
+        # Configure WebGUI Knowledge Layer
+        webgui_schema = Path(_settings.webgui_schema_file)
+        webgui_screenshots = Path(_settings.webgui_screenshots_dir)
+        if webgui_schema.exists():
+            configure_webgui(
+                schema_file=webgui_schema,
+                screenshots_dir=webgui_screenshots,
+            )
+        else:
+            logger.warning(
+                "WebGUI schema file not found at %s — WebGUI tools will "
+                "return errors until the schema is available.",
+                webgui_schema,
+            )
 
         logger.info(
             f"Initialized {_settings.mcp_server_name} v{_settings.mcp_server_version} "

--- a/src/webgui/__init__.py
+++ b/src/webgui/__init__.py
@@ -1,0 +1,7 @@
+"""WebGUI Knowledge Layer for FortiMonitor MCP Server.
+
+Provides static, read-only access to crawled FortiMonitor WebGUI data
+including page structure, UI elements, forms, modals, and screenshots.
+"""
+
+__version__ = "1.0.0"

--- a/src/webgui/store.py
+++ b/src/webgui/store.py
@@ -1,0 +1,532 @@
+"""Schema store for WebGUI crawl data.
+
+Lazy-loads the crawl JSON schema and builds in-memory indexes for fast
+querying of page structure, UI elements, forms, modals, and navigation.
+"""
+
+import json
+import logging
+import re
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+from urllib.parse import urlparse
+
+logger = logging.getLogger(__name__)
+
+
+class SchemaStore:
+    """Read-only store for crawled WebGUI schema data.
+
+    Loads the schema JSON lazily on first access and builds word-level
+    indexes for fast lookups across page titles, element labels, form
+    fields, and modal titles.
+    """
+
+    def __init__(self, schema_file: Path, screenshots_dir: Path):
+        self._schema_file = Path(schema_file)
+        self._screenshots_dir = Path(screenshots_dir)
+        self._data: Optional[Dict] = None
+        # Indexes (built once on load)
+        self._title_index: Dict[str, List[str]] = {}  # word -> [url, ...]
+        self._element_index: Dict[str, List[str]] = {}  # word -> [url, ...]
+        self._form_index: Dict[str, List[str]] = {}  # word -> [url, ...]
+        self._modal_index: Dict[str, List[str]] = {}  # word -> [url, ...]
+        self._page_id_map: Dict[str, str] = {}  # page_id -> url
+        self._url_categories: Dict[str, List[str]] = {}  # category -> [url, ...]
+
+    def _ensure_loaded(self) -> None:
+        """Load schema and build indexes if not already done."""
+        if self._data is not None:
+            return
+
+        logger.info("Loading WebGUI schema from %s", self._schema_file)
+        with open(self._schema_file, "r", encoding="utf-8") as f:
+            self._data = json.load(f)
+        logger.info("Schema loaded, building indexes...")
+        self._build_indexes()
+        logger.info("Indexes built for %d pages", len(self._data.get("pages", {})))
+
+    def _tokenize(self, text: str) -> List[str]:
+        """Split text into lowercase word tokens."""
+        return re.findall(r"[a-z0-9]+", text.lower())
+
+    def _add_to_index(
+        self, index: Dict[str, List[str]], text: str, url: str
+    ) -> None:
+        """Add all words from text to the given index, mapped to url."""
+        for word in self._tokenize(text):
+            if url not in index.get(word, []):
+                index.setdefault(word, []).append(url)
+
+    def _categorize_url(self, url: str) -> str:
+        """Extract a category from a URL path (first path segment)."""
+        parsed = urlparse(url)
+        parts = [p for p in parsed.path.strip("/").split("/") if p]
+        return parts[0] if parts else "root"
+
+    def _build_indexes(self) -> None:
+        """Build in-memory indexes from loaded schema data."""
+        pages = self._data.get("pages", {})
+
+        for url, page in pages.items():
+            page_id = page.get("page_id", "")
+            title = page.get("title", "")
+
+            # page_id -> url map
+            if page_id:
+                self._page_id_map[page_id] = url
+
+            # URL category map
+            category = self._categorize_url(url)
+            self._url_categories.setdefault(category, []).append(url)
+
+            # Title index
+            if title:
+                self._add_to_index(self._title_index, title, url)
+
+            # Element label index (from sections)
+            for section in page.get("sections", []):
+                for elem in section.get("elements", []):
+                    label = elem.get("label", "")
+                    if label:
+                        self._add_to_index(self._element_index, label, url)
+
+            # Form field index
+            for form in page.get("forms", []):
+                form_title = form.get("title", "")
+                if form_title:
+                    self._add_to_index(self._form_index, form_title, url)
+                for field in form.get("fields", []):
+                    label = field.get("label", "")
+                    if label:
+                        self._add_to_index(self._form_index, label, url)
+
+            # Modal title index
+            for modal in page.get("modals", []):
+                modal_title = modal.get("title", "")
+                if modal_title:
+                    self._add_to_index(self._modal_index, modal_title, url)
+                # Also index modal form fields
+                for form in modal.get("forms", []):
+                    for field in form.get("fields", []):
+                        label = field.get("label", "")
+                        if label:
+                            self._add_to_index(self._modal_index, label, url)
+
+    def _resolve_url(self, url: Optional[str] = None, page_id: Optional[str] = None) -> Optional[str]:
+        """Resolve a page_id to a URL, or validate a URL exists."""
+        self._ensure_loaded()
+        if url:
+            if url in self._data["pages"]:
+                return url
+            return None
+        if page_id:
+            return self._page_id_map.get(page_id)
+        return None
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def get_metadata(self) -> Dict[str, Any]:
+        """Return crawl metadata and summary statistics."""
+        self._ensure_loaded()
+        meta = dict(self._data.get("crawl_metadata", {}))
+        meta["schema_version"] = self._data.get("schema_version", "unknown")
+        meta["total_pages_loaded"] = len(self._data.get("pages", {}))
+        meta["categories"] = sorted(self._url_categories.keys())
+        return meta
+
+    def list_pages(
+        self,
+        category: Optional[str] = None,
+        limit: int = 50,
+        offset: int = 0,
+    ) -> Dict[str, Any]:
+        """List crawled pages with pagination.
+
+        Returns page summaries (url, title, page_id, category) without
+        the full element/form/modal data.
+        """
+        self._ensure_loaded()
+        pages = self._data.get("pages", {})
+
+        if category:
+            urls = self._url_categories.get(category, [])
+        else:
+            urls = list(pages.keys())
+
+        urls_sorted = sorted(urls)
+        total = len(urls_sorted)
+        page_slice = urls_sorted[offset : offset + limit]
+
+        summaries = []
+        for url in page_slice:
+            page = pages[url]
+            summaries.append(
+                {
+                    "url": url,
+                    "title": page.get("title", ""),
+                    "page_id": page.get("page_id", ""),
+                    "category": self._categorize_url(url),
+                    "num_sections": len(page.get("sections", [])),
+                    "num_forms": len(page.get("forms", [])),
+                    "num_modals": len(page.get("modals", [])),
+                    "num_links": len(page.get("links", [])),
+                    "has_screenshot": page.get("screenshot_path") is not None,
+                }
+            )
+
+        return {
+            "total": total,
+            "offset": offset,
+            "limit": limit,
+            "count": len(summaries),
+            "pages": summaries,
+        }
+
+    def get_page(
+        self,
+        url: Optional[str] = None,
+        page_id: Optional[str] = None,
+        include_elements: bool = False,
+    ) -> Optional[Dict[str, Any]]:
+        """Get full page data by URL or page_id.
+
+        By default, omits individual element details from sections to
+        keep response size manageable. Set include_elements=True for
+        full element data (capped at 500 elements).
+        """
+        resolved_url = self._resolve_url(url=url, page_id=page_id)
+        if not resolved_url:
+            return None
+
+        page = self._data["pages"][resolved_url]
+        result = {
+            "url": resolved_url,
+            "title": page.get("title", ""),
+            "page_id": page.get("page_id", ""),
+            "breadcrumbs": page.get("breadcrumbs", []),
+            "category": self._categorize_url(resolved_url),
+            "has_screenshot": page.get("screenshot_path") is not None,
+            "links": page.get("links", []),
+            "forms": page.get("forms", []),
+            "modals_summary": [
+                {
+                    "modal_id": m.get("modal_id", ""),
+                    "title": m.get("title", ""),
+                    "num_elements": len(m.get("elements", [])),
+                    "num_forms": len(m.get("forms", [])),
+                }
+                for m in page.get("modals", [])
+            ],
+        }
+
+        if include_elements:
+            all_elements = []
+            for section in page.get("sections", []):
+                for elem in section.get("elements", []):
+                    all_elements.append(elem)
+                    if len(all_elements) >= 500:
+                        break
+                if len(all_elements) >= 500:
+                    break
+            result["elements"] = all_elements
+            result["elements_truncated"] = len(all_elements) >= 500
+        else:
+            # Provide section summaries
+            result["sections"] = [
+                {
+                    "heading": s.get("heading", ""),
+                    "num_elements": len(s.get("elements", [])),
+                }
+                for s in page.get("sections", [])
+            ]
+
+        return result
+
+    def search(
+        self,
+        query: str,
+        search_in: Optional[str] = None,
+        limit: int = 20,
+    ) -> Dict[str, Any]:
+        """Search across indexed content using word-level matching.
+
+        Args:
+            query: Search terms (space-separated words).
+            search_in: Restrict to "titles", "elements", "forms", or
+                       "modals". None searches all.
+            limit: Max results to return.
+
+        Returns dict with results list, each containing url, title,
+        match_type, and relevance score.
+        """
+        self._ensure_loaded()
+        tokens = self._tokenize(query)
+        if not tokens:
+            return {"query": query, "results": [], "total": 0}
+
+        # Choose which indexes to search
+        indexes_to_search = []
+        if search_in == "titles":
+            indexes_to_search = [("title", self._title_index)]
+        elif search_in == "elements":
+            indexes_to_search = [("element", self._element_index)]
+        elif search_in == "forms":
+            indexes_to_search = [("form", self._form_index)]
+        elif search_in == "modals":
+            indexes_to_search = [("modal", self._modal_index)]
+        else:
+            indexes_to_search = [
+                ("title", self._title_index),
+                ("element", self._element_index),
+                ("form", self._form_index),
+                ("modal", self._modal_index),
+            ]
+
+        # Score URLs: count how many query tokens match in each index
+        url_scores: Dict[str, Dict] = {}  # url -> {score, match_types}
+
+        for match_type, index in indexes_to_search:
+            for token in tokens:
+                for url in index.get(token, []):
+                    if url not in url_scores:
+                        url_scores[url] = {"score": 0, "match_types": set()}
+                    url_scores[url]["score"] += 1
+                    url_scores[url]["match_types"].add(match_type)
+
+        # Sort by score descending
+        scored = sorted(url_scores.items(), key=lambda x: x[1]["score"], reverse=True)
+        scored = scored[:limit]
+
+        pages = self._data.get("pages", {})
+        results = []
+        for url, info in scored:
+            page = pages.get(url, {})
+            results.append(
+                {
+                    "url": url,
+                    "title": page.get("title", ""),
+                    "page_id": page.get("page_id", ""),
+                    "match_types": sorted(info["match_types"]),
+                    "relevance_score": info["score"],
+                }
+            )
+
+        return {
+            "query": query,
+            "total": len(results),
+            "results": results,
+        }
+
+    def get_navigation_tree(self, max_depth: int = 3) -> Dict[str, Any]:
+        """Build a hierarchical navigation tree from URL paths.
+
+        Groups pages by URL path segments up to max_depth.
+        """
+        self._ensure_loaded()
+        pages = self._data.get("pages", {})
+
+        tree: Dict[str, Any] = {"children": {}, "pages": []}
+
+        for url, page in pages.items():
+            parsed = urlparse(url)
+            parts = [p for p in parsed.path.strip("/").split("/") if p]
+            parts = parts[:max_depth]
+
+            node = tree
+            for part in parts:
+                if part not in node["children"]:
+                    node["children"][part] = {"children": {}, "pages": []}
+                node = node["children"][part]
+
+            node["pages"].append(
+                {
+                    "url": url,
+                    "title": page.get("title", ""),
+                    "page_id": page.get("page_id", ""),
+                }
+            )
+
+        return self._serialize_tree(tree)
+
+    def _serialize_tree(self, node: Dict) -> Dict[str, Any]:
+        """Convert tree to a clean serializable dict."""
+        result: Dict[str, Any] = {}
+        if node["pages"]:
+            result["pages"] = node["pages"]
+        for name, child in sorted(node["children"].items()):
+            result[name] = self._serialize_tree(child)
+        return result
+
+    def get_screenshot_path(
+        self, url: Optional[str] = None, page_id: Optional[str] = None
+    ) -> Optional[Path]:
+        """Resolve the filesystem path to a page's screenshot.
+
+        The schema stores paths like "data/webgui/screenshots/crawl-xxx/file.png"
+        but actual files live in the configured screenshots_dir. We extract the
+        filename and look for it there.
+        """
+        resolved_url = self._resolve_url(url=url, page_id=page_id)
+        if not resolved_url:
+            return None
+
+        page = self._data["pages"][resolved_url]
+        schema_path = page.get("screenshot_path")
+        if not schema_path:
+            return None
+
+        # Extract just the filename from the schema path
+        filename = Path(schema_path).name
+        actual_path = self._screenshots_dir / filename
+
+        if actual_path.exists():
+            return actual_path
+        return None
+
+    def describe_page(
+        self, url: Optional[str] = None, page_id: Optional[str] = None
+    ) -> Optional[str]:
+        """Generate a human-readable markdown description of a page.
+
+        Includes title, breadcrumbs, sections summary, forms, modals,
+        and navigation links.
+        """
+        resolved_url = self._resolve_url(url=url, page_id=page_id)
+        if not resolved_url:
+            return None
+
+        page = self._data["pages"][resolved_url]
+        title = page.get("title", "Untitled")
+        breadcrumbs = page.get("breadcrumbs", [])
+
+        lines = [f"# {title}", ""]
+
+        if breadcrumbs:
+            lines.append(f"**Breadcrumbs:** {' > '.join(breadcrumbs)}")
+            lines.append("")
+
+        lines.append(f"**URL:** `{resolved_url}`")
+        lines.append("")
+
+        # Sections summary
+        sections = page.get("sections", [])
+        if sections:
+            total_elements = sum(len(s.get("elements", [])) for s in sections)
+            lines.append(f"## Page Elements ({total_elements} total)")
+            lines.append("")
+            for section in sections:
+                heading = section.get("heading", "Unnamed Section")
+                elements = section.get("elements", [])
+                # Summarize element types
+                type_counts: Dict[str, int] = {}
+                for elem in elements:
+                    etype = elem.get("type", "unknown")
+                    type_counts[etype] = type_counts.get(etype, 0) + 1
+                type_summary = ", ".join(
+                    f"{count} {etype}{'s' if count > 1 else ''}"
+                    for etype, count in sorted(type_counts.items())
+                )
+                lines.append(f"- **{heading}**: {type_summary}")
+            lines.append("")
+
+        # Forms
+        forms = page.get("forms", [])
+        if forms:
+            lines.append(f"## Forms ({len(forms)})")
+            lines.append("")
+            for form in forms:
+                ftitle = form.get("title", "Untitled Form")
+                fields = form.get("fields", [])
+                field_names = [f.get("label", "?") for f in fields[:10]]
+                lines.append(
+                    f"- **{ftitle}** ({len(fields)} fields): "
+                    + ", ".join(field_names)
+                    + ("..." if len(fields) > 10 else "")
+                )
+            lines.append("")
+
+        # Modals
+        modals = page.get("modals", [])
+        if modals:
+            lines.append(f"## Modals/Dialogs ({len(modals)})")
+            lines.append("")
+            for modal in modals:
+                mtitle = modal.get("title", "Untitled Modal")
+                mforms = modal.get("forms", [])
+                melems = modal.get("elements", [])
+                parts = []
+                if melems:
+                    parts.append(f"{len(melems)} elements")
+                if mforms:
+                    parts.append(f"{len(mforms)} forms")
+                detail = ", ".join(parts) if parts else "empty"
+                lines.append(f"- **{mtitle}** ({detail})")
+            lines.append("")
+
+        # Links
+        links = page.get("links", [])
+        if links:
+            nav_links = [l for l in links if l.get("type") == "navigation"]
+            action_links = [l for l in links if l.get("type") == "action"]
+            external_links = [l for l in links if l.get("type") == "external"]
+
+            lines.append(f"## Links ({len(links)} total)")
+            lines.append("")
+            if nav_links:
+                lines.append(
+                    f"- **Navigation:** {len(nav_links)} links to other pages"
+                )
+            if action_links:
+                lines.append(f"- **Actions:** {len(action_links)} action links")
+            if external_links:
+                lines.append(
+                    f"- **External:** {len(external_links)} external links"
+                )
+            lines.append("")
+
+        return "\n".join(lines)
+
+    def get_forms(
+        self,
+        url: Optional[str] = None,
+        page_id: Optional[str] = None,
+        form_id: Optional[str] = None,
+    ) -> Optional[Dict[str, Any]]:
+        """Get form details for a page, optionally filtered by form_id.
+
+        Returns forms from both the page level and within modals.
+        """
+        resolved_url = self._resolve_url(url=url, page_id=page_id)
+        if not resolved_url:
+            return None
+
+        page = self._data["pages"][resolved_url]
+        all_forms = []
+
+        # Page-level forms
+        for form in page.get("forms", []):
+            all_forms.append({"source": "page", **form})
+
+        # Modal forms
+        for modal in page.get("modals", []):
+            for form in modal.get("forms", []):
+                all_forms.append(
+                    {
+                        "source": f"modal:{modal.get('modal_id', '')}",
+                        "modal_title": modal.get("title", ""),
+                        **form,
+                    }
+                )
+
+        if form_id:
+            all_forms = [f for f in all_forms if f.get("form_id") == form_id]
+
+        return {
+            "url": resolved_url,
+            "title": page.get("title", ""),
+            "total_forms": len(all_forms),
+            "forms": all_forms,
+        }

--- a/src/webgui/tools.py
+++ b/src/webgui/tools.py
@@ -1,0 +1,467 @@
+"""WebGUI knowledge layer MCP tools.
+
+Provides 7 read-only tools for querying crawled FortiMonitor WebGUI data:
+page listings, page details, search, screenshots, navigation, page
+descriptions, and form details.
+"""
+
+import base64
+import json
+import logging
+from pathlib import Path
+from typing import Any, List
+
+from mcp.types import ImageContent, TextContent, Tool
+
+from .store import SchemaStore
+
+logger = logging.getLogger(__name__)
+
+# Module-level store instance (configured during server init)
+_store: SchemaStore | None = None
+
+
+def configure(schema_file: Path, screenshots_dir: Path) -> None:
+    """Configure the WebGUI tools with schema and screenshot paths.
+
+    Called during server initialization.
+    """
+    global _store
+    _store = SchemaStore(schema_file=schema_file, screenshots_dir=screenshots_dir)
+    logger.info("WebGUI knowledge layer configured: schema=%s, screenshots=%s",
+                schema_file, screenshots_dir)
+
+
+def _get_store() -> SchemaStore:
+    """Get the configured store, raising a clear error if not configured."""
+    if _store is None:
+        raise RuntimeError(
+            "WebGUI knowledge layer not configured. "
+            "Ensure the schema file exists at the configured path."
+        )
+    return _store
+
+
+# =============================================================================
+# Tool Definitions
+# =============================================================================
+
+
+def ui_list_pages_tool_definition() -> Tool:
+    return Tool(
+        name="ui_list_pages",
+        description=(
+            "List crawled FortiMonitor WebGUI pages. Returns page summaries "
+            "including URL, title, and counts of forms/modals/elements. "
+            "Supports filtering by URL category and pagination."
+        ),
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "category": {
+                    "type": "string",
+                    "description": (
+                        "Filter by URL path category (e.g. 'report', 'application', "
+                        "'incidents'). Omit to list all pages."
+                    ),
+                },
+                "limit": {
+                    "type": "integer",
+                    "description": "Max pages to return (default: 50, max: 200)",
+                    "default": 50,
+                },
+                "offset": {
+                    "type": "integer",
+                    "description": "Pagination offset (default: 0)",
+                    "default": 0,
+                },
+            },
+            "required": [],
+        },
+    )
+
+
+def ui_get_page_tool_definition() -> Tool:
+    return Tool(
+        name="ui_get_page",
+        description=(
+            "Get full details for a specific FortiMonitor WebGUI page including "
+            "sections, forms, modals, and navigation links. Provide either "
+            "the page URL or page_id."
+        ),
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "url": {
+                    "type": "string",
+                    "description": "Full URL of the page (e.g. 'https://my.us01.fortimonitor.com/incidents')",
+                },
+                "page_id": {
+                    "type": "string",
+                    "description": "Page ID from the crawl schema (e.g. 'incidents')",
+                },
+                "include_elements": {
+                    "type": "boolean",
+                    "description": "Include individual UI element details (default: false, can be large)",
+                    "default": False,
+                },
+            },
+            "required": [],
+        },
+    )
+
+
+def ui_search_tool_definition() -> Tool:
+    return Tool(
+        name="ui_search",
+        description=(
+            "Search FortiMonitor WebGUI pages by element labels, form fields, "
+            "page titles, or modal titles. Returns matching pages ranked by "
+            "relevance with match type indicators."
+        ),
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "query": {
+                    "type": "string",
+                    "description": (
+                        "Search terms, e.g. 'notification schedule' or 'server group'"
+                    ),
+                },
+                "search_in": {
+                    "type": "string",
+                    "enum": ["titles", "elements", "forms", "modals"],
+                    "description": (
+                        "Restrict search to a specific index. Omit to search all."
+                    ),
+                },
+                "limit": {
+                    "type": "integer",
+                    "description": "Max results to return (default: 20)",
+                    "default": 20,
+                },
+            },
+            "required": ["query"],
+        },
+    )
+
+
+def ui_get_screenshot_tool_definition() -> Tool:
+    return Tool(
+        name="ui_get_screenshot",
+        description=(
+            "Retrieve a screenshot of a FortiMonitor WebGUI page as a base64-encoded "
+            "PNG image. Provides visual context for understanding page layout."
+        ),
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "url": {
+                    "type": "string",
+                    "description": "Full URL of the page",
+                },
+                "page_id": {
+                    "type": "string",
+                    "description": "Page ID from the crawl schema",
+                },
+            },
+            "required": [],
+        },
+    )
+
+
+def ui_get_navigation_tool_definition() -> Tool:
+    return Tool(
+        name="ui_get_navigation",
+        description=(
+            "Get the FortiMonitor WebGUI navigation tree showing how pages "
+            "are organized by URL path hierarchy."
+        ),
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "max_depth": {
+                    "type": "integer",
+                    "description": "Maximum depth of the navigation tree (default: 3)",
+                    "default": 3,
+                },
+            },
+            "required": [],
+        },
+    )
+
+
+def ui_describe_page_tool_definition() -> Tool:
+    return Tool(
+        name="ui_describe_page",
+        description=(
+            "Generate a human-readable markdown description of a FortiMonitor "
+            "WebGUI page including its sections, forms, modals, and navigation "
+            "links. Good for understanding what a page does without viewing "
+            "raw schema data."
+        ),
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "url": {
+                    "type": "string",
+                    "description": "Full URL of the page",
+                },
+                "page_id": {
+                    "type": "string",
+                    "description": "Page ID from the crawl schema",
+                },
+            },
+            "required": [],
+        },
+    )
+
+
+def ui_get_form_tool_definition() -> Tool:
+    return Tool(
+        name="ui_get_form",
+        description=(
+            "Get detailed form information for a FortiMonitor WebGUI page, "
+            "including field names, types, required status, and options. "
+            "Returns forms from both the page and its modals."
+        ),
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "url": {
+                    "type": "string",
+                    "description": "Full URL of the page",
+                },
+                "page_id": {
+                    "type": "string",
+                    "description": "Page ID from the crawl schema",
+                },
+                "form_id": {
+                    "type": "string",
+                    "description": "Specific form ID to retrieve (omit for all forms on the page)",
+                },
+            },
+            "required": [],
+        },
+    )
+
+
+# =============================================================================
+# Tool Handlers
+# =============================================================================
+
+
+async def handle_ui_list_pages(
+    arguments: dict, client: Any
+) -> List[TextContent]:
+    """Handle ui_list_pages tool execution."""
+    try:
+        store = _get_store()
+        category = arguments.get("category")
+        limit = min(arguments.get("limit", 50), 200)
+        offset = arguments.get("offset", 0)
+
+        result = store.list_pages(category=category, limit=limit, offset=offset)
+        return [TextContent(type="text", text=json.dumps(result, indent=2))]
+    except Exception as e:
+        logger.exception("Error in ui_list_pages")
+        return [TextContent(type="text", text=f"Error listing pages: {e}")]
+
+
+async def handle_ui_get_page(
+    arguments: dict, client: Any
+) -> List[TextContent]:
+    """Handle ui_get_page tool execution."""
+    try:
+        store = _get_store()
+        url = arguments.get("url")
+        page_id = arguments.get("page_id")
+        include_elements = arguments.get("include_elements", False)
+
+        if not url and not page_id:
+            return [TextContent(
+                type="text",
+                text="Error: provide either 'url' or 'page_id' parameter",
+            )]
+
+        result = store.get_page(
+            url=url, page_id=page_id, include_elements=include_elements
+        )
+        if result is None:
+            identifier = url or page_id
+            return [TextContent(
+                type="text",
+                text=f"Page not found: {identifier}",
+            )]
+
+        return [TextContent(type="text", text=json.dumps(result, indent=2))]
+    except Exception as e:
+        logger.exception("Error in ui_get_page")
+        return [TextContent(type="text", text=f"Error getting page: {e}")]
+
+
+async def handle_ui_search(
+    arguments: dict, client: Any
+) -> List[TextContent]:
+    """Handle ui_search tool execution."""
+    try:
+        store = _get_store()
+        query = arguments.get("query", "")
+        search_in = arguments.get("search_in")
+        limit = min(arguments.get("limit", 20), 100)
+
+        if not query:
+            return [TextContent(
+                type="text",
+                text="Error: 'query' parameter is required",
+            )]
+
+        result = store.search(query=query, search_in=search_in, limit=limit)
+        return [TextContent(type="text", text=json.dumps(result, indent=2))]
+    except Exception as e:
+        logger.exception("Error in ui_search")
+        return [TextContent(type="text", text=f"Error searching: {e}")]
+
+
+async def handle_ui_get_screenshot(
+    arguments: dict, client: Any
+) -> list:
+    """Handle ui_get_screenshot tool execution.
+
+    Returns both ImageContent (base64 PNG) and TextContent (context).
+    """
+    try:
+        store = _get_store()
+        url = arguments.get("url")
+        page_id = arguments.get("page_id")
+
+        if not url and not page_id:
+            return [TextContent(
+                type="text",
+                text="Error: provide either 'url' or 'page_id' parameter",
+            )]
+
+        screenshot_path = store.get_screenshot_path(url=url, page_id=page_id)
+        if screenshot_path is None:
+            identifier = url or page_id
+            return [TextContent(
+                type="text",
+                text=f"No screenshot available for: {identifier}",
+            )]
+
+        # Read and encode the screenshot
+        with open(screenshot_path, "rb") as f:
+            image_data = base64.b64encode(f.read()).decode("utf-8")
+
+        # Get page context
+        page = store.get_page(url=url, page_id=page_id)
+        context = ""
+        if page:
+            context = f"Screenshot of: {page.get('title', 'Unknown')} ({page.get('url', '')})"
+
+        return [
+            ImageContent(type="image", data=image_data, mimeType="image/png"),
+            TextContent(type="text", text=context),
+        ]
+    except Exception as e:
+        logger.exception("Error in ui_get_screenshot")
+        return [TextContent(type="text", text=f"Error getting screenshot: {e}")]
+
+
+async def handle_ui_get_navigation(
+    arguments: dict, client: Any
+) -> List[TextContent]:
+    """Handle ui_get_navigation tool execution."""
+    try:
+        store = _get_store()
+        max_depth = min(arguments.get("max_depth", 3), 10)
+
+        result = store.get_navigation_tree(max_depth=max_depth)
+        return [TextContent(type="text", text=json.dumps(result, indent=2))]
+    except Exception as e:
+        logger.exception("Error in ui_get_navigation")
+        return [TextContent(type="text", text=f"Error getting navigation: {e}")]
+
+
+async def handle_ui_describe_page(
+    arguments: dict, client: Any
+) -> List[TextContent]:
+    """Handle ui_describe_page tool execution."""
+    try:
+        store = _get_store()
+        url = arguments.get("url")
+        page_id = arguments.get("page_id")
+
+        if not url and not page_id:
+            return [TextContent(
+                type="text",
+                text="Error: provide either 'url' or 'page_id' parameter",
+            )]
+
+        description = store.describe_page(url=url, page_id=page_id)
+        if description is None:
+            identifier = url or page_id
+            return [TextContent(
+                type="text",
+                text=f"Page not found: {identifier}",
+            )]
+
+        return [TextContent(type="text", text=description)]
+    except Exception as e:
+        logger.exception("Error in ui_describe_page")
+        return [TextContent(type="text", text=f"Error describing page: {e}")]
+
+
+async def handle_ui_get_form(
+    arguments: dict, client: Any
+) -> List[TextContent]:
+    """Handle ui_get_form tool execution."""
+    try:
+        store = _get_store()
+        url = arguments.get("url")
+        page_id = arguments.get("page_id")
+        form_id = arguments.get("form_id")
+
+        if not url and not page_id:
+            return [TextContent(
+                type="text",
+                text="Error: provide either 'url' or 'page_id' parameter",
+            )]
+
+        result = store.get_forms(url=url, page_id=page_id, form_id=form_id)
+        if result is None:
+            identifier = url or page_id
+            return [TextContent(
+                type="text",
+                text=f"Page not found: {identifier}",
+            )]
+
+        return [TextContent(type="text", text=json.dumps(result, indent=2))]
+    except Exception as e:
+        logger.exception("Error in ui_get_form")
+        return [TextContent(type="text", text=f"Error getting forms: {e}")]
+
+
+# =============================================================================
+# Module Registration (dict pattern)
+# =============================================================================
+
+WEBGUI_TOOL_DEFINITIONS = {
+    "ui_list_pages": ui_list_pages_tool_definition,
+    "ui_get_page": ui_get_page_tool_definition,
+    "ui_search": ui_search_tool_definition,
+    "ui_get_screenshot": ui_get_screenshot_tool_definition,
+    "ui_get_navigation": ui_get_navigation_tool_definition,
+    "ui_describe_page": ui_describe_page_tool_definition,
+    "ui_get_form": ui_get_form_tool_definition,
+}
+
+WEBGUI_HANDLERS = {
+    "ui_list_pages": handle_ui_list_pages,
+    "ui_get_page": handle_ui_get_page,
+    "ui_search": handle_ui_search,
+    "ui_get_screenshot": handle_ui_get_screenshot,
+    "ui_get_navigation": handle_ui_get_navigation,
+    "ui_describe_page": handle_ui_describe_page,
+    "ui_get_form": handle_ui_get_form,
+}

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -52,10 +52,10 @@ class TestRegistryIntegrity:
     """Verify the tool registry loads correctly."""
 
     def test_total_tool_count(self, registry):
-        """All 241 tools are registered."""
+        """All 248 tools are registered (241 original + 7 WebGUI)."""
         defns, handlers = registry
-        assert len(defns) >= 241, (
-            f"Expected at least 241 tools, got {len(defns)}"
+        assert len(defns) >= 248, (
+            f"Expected at least 248 tools, got {len(defns)}"
         )
 
     def test_definition_handler_count_match(self, registry):
@@ -193,6 +193,7 @@ class TestDictModuleExportConsistency:
         ("src.tools.onsight", "ONSIGHT_TOOL_DEFINITIONS", "ONSIGHT_HANDLERS"),
         ("src.tools.fabric", "FABRIC_TOOL_DEFINITIONS", "FABRIC_HANDLERS"),
         ("src.tools.countermeasures", "COUNTERMEASURES_TOOL_DEFINITIONS", "COUNTERMEASURES_HANDLERS"),
+        ("src.webgui.tools", "WEBGUI_TOOL_DEFINITIONS", "WEBGUI_HANDLERS"),
     ]
 
     @pytest.mark.parametrize("module_path,defn_name,handler_name", DICT_MODULES)

--- a/tests/test_webgui_tools.py
+++ b/tests/test_webgui_tools.py
@@ -1,0 +1,708 @@
+"""Tests for the WebGUI knowledge layer tools and SchemaStore.
+
+Covers:
+  - Tool definition / handler registration consistency
+  - SchemaStore unit tests with a small inline fixture
+  - Async handler tests with mocked store
+"""
+
+import asyncio
+import json
+import os
+import sys
+import pytest
+from pathlib import Path
+from unittest.mock import MagicMock, patch, AsyncMock
+
+# Ensure src is on path
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+# Minimal 3-page schema fixture
+SAMPLE_SCHEMA = {
+    "schema_version": "1.0.0",
+    "crawl_metadata": {
+        "crawl_id": "crawl-test123",
+        "target_url": "https://example.fortimonitor.com",
+        "application_name": "FortiMonitor",
+        "total_pages": 3,
+        "total_elements": 12,
+        "total_forms": 3,
+        "total_modals": 2,
+        "coverage": {
+            "total_links_discovered": 50,
+            "total_links_crawled": 3,
+            "total_unique_patterns": 3,
+        },
+    },
+    "pages": {
+        "https://example.fortimonitor.com/incidents": {
+            "page_id": "incidents",
+            "url": "https://example.fortimonitor.com/incidents",
+            "title": "Incidents | FortiMonitor",
+            "breadcrumbs": ["All Incidents"],
+            "screenshot_path": "data/webgui/screenshots/crawl-test123/page_incidents.png",
+            "sections": [
+                {
+                    "heading": "Page Elements",
+                    "elements": [
+                        {
+                            "element_id": "elem-0",
+                            "type": "button",
+                            "label": "Acknowledge",
+                            "selector": "#ack-btn",
+                            "attributes": {},
+                            "position": {"x": 10, "y": 20, "width": 80, "height": 30},
+                            "children": [],
+                        },
+                        {
+                            "element_id": "elem-1",
+                            "type": "link",
+                            "label": "View Details",
+                            "selector": ".details-link",
+                            "attributes": {"href": "/incidents/123"},
+                            "position": None,
+                            "children": [],
+                        },
+                    ],
+                }
+            ],
+            "modals": [
+                {
+                    "modal_id": "confirm-ack",
+                    "title": "Confirm Acknowledge",
+                    "trigger_element": None,
+                    "elements": [
+                        {
+                            "element_id": "modal-elem-0",
+                            "type": "button",
+                            "label": "Yes",
+                            "selector": "#yes",
+                            "attributes": {},
+                            "position": None,
+                            "children": [],
+                        }
+                    ],
+                    "forms": [],
+                    "screenshot_path": None,
+                }
+            ],
+            "forms": [
+                {
+                    "form_id": "form-0",
+                    "title": "Filter Incidents",
+                    "fields": [
+                        {
+                            "field_id": "filter-status",
+                            "label": "Status",
+                            "type": "select",
+                            "required": False,
+                            "placeholder": "",
+                            "options": ["Active", "Resolved"],
+                            "validation": None,
+                            "selector": "#filter-status",
+                        }
+                    ],
+                    "submit_button": None,
+                    "selector": "#filter-form",
+                }
+            ],
+            "links": [
+                {
+                    "text": "Server List",
+                    "url": "https://example.fortimonitor.com/report/ListServers",
+                    "type": "navigation",
+                    "source": "sidebar",
+                },
+                {
+                    "text": "Help",
+                    "url": "https://docs.fortinet.com",
+                    "type": "external",
+                    "source": "navigation",
+                },
+            ],
+        },
+        "https://example.fortimonitor.com/report/ListServers": {
+            "page_id": "report-ListServers",
+            "url": "https://example.fortimonitor.com/report/ListServers",
+            "title": "Server List | FortiMonitor",
+            "breadcrumbs": ["Reports", "Server List"],
+            "screenshot_path": "data/webgui/screenshots/crawl-test123/page_report_ListServers.png",
+            "sections": [
+                {
+                    "heading": "Server Table",
+                    "elements": [
+                        {
+                            "element_id": "elem-0",
+                            "type": "input",
+                            "label": "Search servers",
+                            "selector": "#search",
+                            "attributes": {},
+                            "position": None,
+                            "children": [],
+                        }
+                    ],
+                }
+            ],
+            "modals": [],
+            "forms": [
+                {
+                    "form_id": "form-0",
+                    "title": "Server Search",
+                    "fields": [
+                        {
+                            "field_id": "search-field",
+                            "label": "Server name",
+                            "type": "input",
+                            "required": True,
+                            "placeholder": "Enter server name",
+                            "options": [],
+                            "validation": None,
+                            "selector": "#search-input",
+                        }
+                    ],
+                    "submit_button": {
+                        "element_id": "btn-search",
+                        "type": "button",
+                        "label": "Search",
+                        "selector": "#search-btn",
+                        "attributes": {},
+                        "position": None,
+                        "children": [],
+                    },
+                    "selector": "#search-form",
+                }
+            ],
+            "links": [],
+        },
+        "https://example.fortimonitor.com/application": {
+            "page_id": "application",
+            "url": "https://example.fortimonitor.com/application",
+            "title": "Applications | FortiMonitor",
+            "breadcrumbs": ["Applications"],
+            "screenshot_path": None,
+            "sections": [],
+            "modals": [
+                {
+                    "modal_id": "add-app",
+                    "title": "Add Application",
+                    "trigger_element": "elem-add",
+                    "elements": [],
+                    "forms": [
+                        {
+                            "form_id": "form-modal-0",
+                            "title": "New Application",
+                            "fields": [
+                                {
+                                    "field_id": "app-name",
+                                    "label": "Application Name",
+                                    "type": "input",
+                                    "required": True,
+                                    "placeholder": "",
+                                    "options": [],
+                                    "validation": None,
+                                    "selector": "#app-name",
+                                }
+                            ],
+                            "submit_button": None,
+                            "selector": "#new-app-form",
+                        }
+                    ],
+                    "screenshot_path": None,
+                }
+            ],
+            "forms": [],
+            "links": [],
+        },
+    },
+}
+
+
+@pytest.fixture
+def schema_file(tmp_path):
+    """Write sample schema to a temp file and return its path."""
+    filepath = tmp_path / "test_schema.json"
+    filepath.write_text(json.dumps(SAMPLE_SCHEMA))
+    return filepath
+
+
+@pytest.fixture
+def screenshots_dir(tmp_path):
+    """Create a screenshots dir with a fake PNG file."""
+    ss_dir = tmp_path / "screenshots"
+    ss_dir.mkdir()
+    # Create a tiny fake PNG for the incidents page
+    fake_png = ss_dir / "page_incidents.png"
+    # Minimal valid PNG (1x1 pixel, transparent)
+    fake_png.write_bytes(
+        b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\x00\x01"
+        b"\x00\x00\x00\x01\x08\x06\x00\x00\x00\x1f\x15\xc4\x89"
+        b"\x00\x00\x00\nIDATx\x9cc\x00\x01\x00\x00\x05\x00\x01"
+        b"\r\n\xb4\x00\x00\x00\x00IEND\xaeB`\x82"
+    )
+    return ss_dir
+
+
+@pytest.fixture
+def store(schema_file, screenshots_dir):
+    """Create a SchemaStore with the test fixtures."""
+    from src.webgui.store import SchemaStore
+
+    return SchemaStore(schema_file=schema_file, screenshots_dir=screenshots_dir)
+
+
+# ---------------------------------------------------------------------------
+# TestWebguiToolDefinitions
+# ---------------------------------------------------------------------------
+
+
+class TestWebguiToolDefinitions:
+    """Verify tool definitions and handler registration."""
+
+    def test_all_seven_tools_defined(self):
+        """WEBGUI_TOOL_DEFINITIONS has exactly 7 entries."""
+        from src.webgui.tools import WEBGUI_TOOL_DEFINITIONS
+
+        assert len(WEBGUI_TOOL_DEFINITIONS) == 7
+
+    def test_all_seven_handlers_defined(self):
+        """WEBGUI_HANDLERS has exactly 7 entries."""
+        from src.webgui.tools import WEBGUI_HANDLERS
+
+        assert len(WEBGUI_HANDLERS) == 7
+
+    def test_definition_handler_keys_match(self):
+        """Definition dict keys match handler dict keys."""
+        from src.webgui.tools import WEBGUI_TOOL_DEFINITIONS, WEBGUI_HANDLERS
+
+        assert set(WEBGUI_TOOL_DEFINITIONS.keys()) == set(WEBGUI_HANDLERS.keys())
+
+    def test_expected_tool_names(self):
+        """All 7 expected tool names are present."""
+        from src.webgui.tools import WEBGUI_TOOL_DEFINITIONS
+
+        expected = {
+            "ui_list_pages",
+            "ui_get_page",
+            "ui_search",
+            "ui_get_screenshot",
+            "ui_get_navigation",
+            "ui_describe_page",
+            "ui_get_form",
+        }
+        assert set(WEBGUI_TOOL_DEFINITIONS.keys()) == expected
+
+    def test_definitions_return_tool_objects(self):
+        """Each definition callable returns a Tool with matching name."""
+        from mcp.types import Tool
+        from src.webgui.tools import WEBGUI_TOOL_DEFINITIONS
+
+        for name, defn_func in WEBGUI_TOOL_DEFINITIONS.items():
+            tool = defn_func()
+            assert isinstance(tool, Tool)
+            assert tool.name == name
+            assert tool.description
+            assert tool.inputSchema
+            assert tool.inputSchema.get("type") == "object"
+
+    def test_all_handlers_are_async(self):
+        """Every handler is an async callable."""
+        import asyncio
+        from src.webgui.tools import WEBGUI_HANDLERS
+
+        for name, handler in WEBGUI_HANDLERS.items():
+            assert callable(handler), f"{name} is not callable"
+            assert asyncio.iscoroutinefunction(handler), f"{name} is not async"
+
+
+# ---------------------------------------------------------------------------
+# TestSchemaStore
+# ---------------------------------------------------------------------------
+
+
+class TestSchemaStore:
+    """Unit tests for SchemaStore with the inline fixture."""
+
+    def test_lazy_loading(self, schema_file, screenshots_dir):
+        """Store does not load JSON until first method call."""
+        from src.webgui.store import SchemaStore
+
+        s = SchemaStore(schema_file=schema_file, screenshots_dir=screenshots_dir)
+        assert s._data is None
+        s.get_metadata()
+        assert s._data is not None
+
+    def test_get_metadata(self, store):
+        """get_metadata returns crawl stats."""
+        meta = store.get_metadata()
+        assert meta["crawl_id"] == "crawl-test123"
+        assert meta["total_pages"] == 3
+        assert meta["total_pages_loaded"] == 3
+        assert meta["schema_version"] == "1.0.0"
+        assert "incidents" in meta["categories"]
+
+    def test_list_pages_all(self, store):
+        """list_pages returns all 3 pages."""
+        result = store.list_pages()
+        assert result["total"] == 3
+        assert result["count"] == 3
+        assert len(result["pages"]) == 3
+
+    def test_list_pages_with_category(self, store):
+        """list_pages filters by category."""
+        result = store.list_pages(category="report")
+        assert result["total"] == 1
+        assert result["pages"][0]["page_id"] == "report-ListServers"
+
+    def test_list_pages_pagination(self, store):
+        """list_pages respects limit and offset."""
+        result = store.list_pages(limit=1, offset=0)
+        assert result["count"] == 1
+        assert result["total"] == 3
+
+        result2 = store.list_pages(limit=1, offset=1)
+        assert result2["count"] == 1
+        assert result2["pages"][0]["url"] != result["pages"][0]["url"]
+
+    def test_list_pages_nonexistent_category(self, store):
+        """list_pages with unknown category returns empty."""
+        result = store.list_pages(category="nonexistent")
+        assert result["total"] == 0
+        assert result["pages"] == []
+
+    def test_get_page_by_url(self, store):
+        """get_page retrieves page data by URL."""
+        page = store.get_page(url="https://example.fortimonitor.com/incidents")
+        assert page is not None
+        assert page["title"] == "Incidents | FortiMonitor"
+        assert page["page_id"] == "incidents"
+        assert "sections" in page  # sections summary when include_elements=False
+
+    def test_get_page_by_page_id(self, store):
+        """get_page retrieves page data by page_id."""
+        page = store.get_page(page_id="report-ListServers")
+        assert page is not None
+        assert page["title"] == "Server List | FortiMonitor"
+
+    def test_get_page_not_found(self, store):
+        """get_page returns None for unknown URL/page_id."""
+        assert store.get_page(url="https://nonexistent.com/foo") is None
+        assert store.get_page(page_id="nonexistent") is None
+
+    def test_get_page_include_elements(self, store):
+        """get_page with include_elements returns element data."""
+        page = store.get_page(
+            url="https://example.fortimonitor.com/incidents",
+            include_elements=True,
+        )
+        assert "elements" in page
+        assert len(page["elements"]) == 2
+        assert page["elements"][0]["label"] == "Acknowledge"
+
+    def test_get_page_modals_summary(self, store):
+        """get_page includes modal summaries."""
+        page = store.get_page(url="https://example.fortimonitor.com/incidents")
+        assert "modals_summary" in page
+        assert len(page["modals_summary"]) == 1
+        assert page["modals_summary"][0]["title"] == "Confirm Acknowledge"
+
+    def test_search_by_title(self, store):
+        """Search finds pages by title words."""
+        result = store.search("incidents")
+        assert result["total"] >= 1
+        urls = [r["url"] for r in result["results"]]
+        assert "https://example.fortimonitor.com/incidents" in urls
+
+    def test_search_by_element_label(self, store):
+        """Search finds pages by element labels."""
+        result = store.search("Acknowledge", search_in="elements")
+        assert result["total"] >= 1
+
+    def test_search_by_form(self, store):
+        """Search finds pages by form field labels."""
+        result = store.search("server name", search_in="forms")
+        assert result["total"] >= 1
+        urls = [r["url"] for r in result["results"]]
+        assert "https://example.fortimonitor.com/report/ListServers" in urls
+
+    def test_search_by_modal(self, store):
+        """Search finds pages by modal titles."""
+        result = store.search("Add Application", search_in="modals")
+        assert result["total"] >= 1
+
+    def test_search_empty_query(self, store):
+        """Search with empty query returns no results."""
+        result = store.search("")
+        assert result["total"] == 0
+
+    def test_search_no_match(self, store):
+        """Search with nonsense query returns no results."""
+        result = store.search("xyznonexistent999")
+        assert result["total"] == 0
+
+    def test_search_multiple_words_scored(self, store):
+        """Search ranks multi-word matches higher."""
+        result = store.search("Filter Incidents")
+        # The incidents page should score higher than others
+        if result["total"] > 0:
+            assert result["results"][0]["url"] == "https://example.fortimonitor.com/incidents"
+
+    def test_get_navigation_tree(self, store):
+        """get_navigation_tree builds a hierarchical structure."""
+        tree = store.get_navigation_tree()
+        assert isinstance(tree, dict)
+        # Should have top-level keys from URL paths
+        assert "incidents" in tree or "report" in tree or "application" in tree
+
+    def test_get_navigation_tree_depth(self, store):
+        """get_navigation_tree respects max_depth."""
+        tree1 = store.get_navigation_tree(max_depth=1)
+        tree3 = store.get_navigation_tree(max_depth=3)
+        # Both should be valid dicts
+        assert isinstance(tree1, dict)
+        assert isinstance(tree3, dict)
+
+    def test_get_screenshot_path_found(self, store, screenshots_dir):
+        """get_screenshot_path resolves to existing file."""
+        path = store.get_screenshot_path(url="https://example.fortimonitor.com/incidents")
+        assert path is not None
+        assert path.exists()
+        assert path.name == "page_incidents.png"
+
+    def test_get_screenshot_path_missing_file(self, store):
+        """get_screenshot_path returns None when file doesn't exist on disk."""
+        # report page has a screenshot_path in schema but no matching file
+        path = store.get_screenshot_path(page_id="report-ListServers")
+        assert path is None
+
+    def test_get_screenshot_path_no_screenshot_in_schema(self, store):
+        """get_screenshot_path returns None when schema has null screenshot_path."""
+        path = store.get_screenshot_path(page_id="application")
+        assert path is None
+
+    def test_get_screenshot_path_unknown_page(self, store):
+        """get_screenshot_path returns None for unknown page."""
+        path = store.get_screenshot_path(url="https://nonexistent.com")
+        assert path is None
+
+    def test_describe_page(self, store):
+        """describe_page generates markdown description."""
+        desc = store.describe_page(url="https://example.fortimonitor.com/incidents")
+        assert desc is not None
+        assert "Incidents | FortiMonitor" in desc
+        assert "Page Elements" in desc
+        assert "Forms" in desc
+        assert "Modals" in desc
+
+    def test_describe_page_not_found(self, store):
+        """describe_page returns None for unknown page."""
+        assert store.describe_page(url="https://nonexistent.com") is None
+
+    def test_get_forms_page_level(self, store):
+        """get_forms returns page-level forms."""
+        result = store.get_forms(url="https://example.fortimonitor.com/incidents")
+        assert result is not None
+        assert result["total_forms"] == 1
+        assert result["forms"][0]["form_id"] == "form-0"
+        assert result["forms"][0]["source"] == "page"
+
+    def test_get_forms_modal_level(self, store):
+        """get_forms includes forms from modals."""
+        result = store.get_forms(page_id="application")
+        assert result is not None
+        assert result["total_forms"] == 1
+        assert "modal:" in result["forms"][0]["source"]
+
+    def test_get_forms_by_form_id(self, store):
+        """get_forms filters by form_id."""
+        result = store.get_forms(
+            url="https://example.fortimonitor.com/incidents",
+            form_id="form-0",
+        )
+        assert result["total_forms"] == 1
+
+        result2 = store.get_forms(
+            url="https://example.fortimonitor.com/incidents",
+            form_id="nonexistent",
+        )
+        assert result2["total_forms"] == 0
+
+    def test_get_forms_not_found(self, store):
+        """get_forms returns None for unknown page."""
+        assert store.get_forms(url="https://nonexistent.com") is None
+
+
+# ---------------------------------------------------------------------------
+# TestWebguiHandlers
+# ---------------------------------------------------------------------------
+
+
+class TestWebguiHandlers:
+    """Async handler tests with a configured store."""
+
+    @pytest.fixture(autouse=True)
+    def setup_store(self, store):
+        """Configure the module-level store for handler tests."""
+        import src.webgui.tools as tools_module
+
+        self._original_store = tools_module._store
+        tools_module._store = store
+        yield
+        tools_module._store = self._original_store
+
+    @pytest.mark.asyncio
+    async def test_handle_ui_list_pages(self):
+        from src.webgui.tools import handle_ui_list_pages
+
+        result = await handle_ui_list_pages({}, None)
+        assert len(result) == 1
+        data = json.loads(result[0].text)
+        assert data["total"] == 3
+
+    @pytest.mark.asyncio
+    async def test_handle_ui_list_pages_category(self):
+        from src.webgui.tools import handle_ui_list_pages
+
+        result = await handle_ui_list_pages({"category": "report"}, None)
+        data = json.loads(result[0].text)
+        assert data["total"] == 1
+
+    @pytest.mark.asyncio
+    async def test_handle_ui_get_page(self):
+        from src.webgui.tools import handle_ui_get_page
+
+        result = await handle_ui_get_page(
+            {"url": "https://example.fortimonitor.com/incidents"}, None
+        )
+        assert len(result) == 1
+        data = json.loads(result[0].text)
+        assert data["title"] == "Incidents | FortiMonitor"
+
+    @pytest.mark.asyncio
+    async def test_handle_ui_get_page_missing_params(self):
+        from src.webgui.tools import handle_ui_get_page
+
+        result = await handle_ui_get_page({}, None)
+        assert "Error" in result[0].text or "error" in result[0].text.lower()
+
+    @pytest.mark.asyncio
+    async def test_handle_ui_get_page_not_found(self):
+        from src.webgui.tools import handle_ui_get_page
+
+        result = await handle_ui_get_page({"url": "https://nonexistent.com"}, None)
+        assert "not found" in result[0].text.lower()
+
+    @pytest.mark.asyncio
+    async def test_handle_ui_search(self):
+        from src.webgui.tools import handle_ui_search
+
+        result = await handle_ui_search({"query": "incidents"}, None)
+        data = json.loads(result[0].text)
+        assert data["total"] >= 1
+
+    @pytest.mark.asyncio
+    async def test_handle_ui_search_empty_query(self):
+        from src.webgui.tools import handle_ui_search
+
+        result = await handle_ui_search({"query": ""}, None)
+        assert "Error" in result[0].text or "error" in result[0].text.lower()
+
+    @pytest.mark.asyncio
+    async def test_handle_ui_get_screenshot_found(self, screenshots_dir):
+        from src.webgui.tools import handle_ui_get_screenshot
+
+        result = await handle_ui_get_screenshot(
+            {"url": "https://example.fortimonitor.com/incidents"}, None
+        )
+        # Should return ImageContent + TextContent
+        assert len(result) == 2
+        assert result[0].type == "image"
+        assert result[1].type == "text"
+
+    @pytest.mark.asyncio
+    async def test_handle_ui_get_screenshot_not_found(self):
+        from src.webgui.tools import handle_ui_get_screenshot
+
+        result = await handle_ui_get_screenshot({"page_id": "application"}, None)
+        assert len(result) == 1
+        assert "No screenshot" in result[0].text
+
+    @pytest.mark.asyncio
+    async def test_handle_ui_get_screenshot_missing_params(self):
+        from src.webgui.tools import handle_ui_get_screenshot
+
+        result = await handle_ui_get_screenshot({}, None)
+        assert "Error" in result[0].text or "error" in result[0].text.lower()
+
+    @pytest.mark.asyncio
+    async def test_handle_ui_get_navigation(self):
+        from src.webgui.tools import handle_ui_get_navigation
+
+        result = await handle_ui_get_navigation({}, None)
+        data = json.loads(result[0].text)
+        assert isinstance(data, dict)
+
+    @pytest.mark.asyncio
+    async def test_handle_ui_describe_page(self):
+        from src.webgui.tools import handle_ui_describe_page
+
+        result = await handle_ui_describe_page(
+            {"url": "https://example.fortimonitor.com/incidents"}, None
+        )
+        assert "Incidents" in result[0].text
+        assert result[0].type == "text"
+
+    @pytest.mark.asyncio
+    async def test_handle_ui_describe_page_missing_params(self):
+        from src.webgui.tools import handle_ui_describe_page
+
+        result = await handle_ui_describe_page({}, None)
+        assert "Error" in result[0].text or "error" in result[0].text.lower()
+
+    @pytest.mark.asyncio
+    async def test_handle_ui_get_form(self):
+        from src.webgui.tools import handle_ui_get_form
+
+        result = await handle_ui_get_form(
+            {"url": "https://example.fortimonitor.com/incidents"}, None
+        )
+        data = json.loads(result[0].text)
+        assert data["total_forms"] == 1
+
+    @pytest.mark.asyncio
+    async def test_handle_ui_get_form_missing_params(self):
+        from src.webgui.tools import handle_ui_get_form
+
+        result = await handle_ui_get_form({}, None)
+        assert "Error" in result[0].text or "error" in result[0].text.lower()
+
+
+# ---------------------------------------------------------------------------
+# TestUnconfiguredStore
+# ---------------------------------------------------------------------------
+
+
+class TestUnconfiguredStore:
+    """Test that handlers return clear errors when store is not configured."""
+
+    @pytest.fixture(autouse=True)
+    def clear_store(self):
+        """Ensure the module-level store is None."""
+        import src.webgui.tools as tools_module
+
+        original = tools_module._store
+        tools_module._store = None
+        yield
+        tools_module._store = original
+
+    @pytest.mark.asyncio
+    async def test_unconfigured_returns_error(self):
+        from src.webgui.tools import handle_ui_list_pages
+
+        result = await handle_ui_list_pages({}, None)
+        assert len(result) == 1
+        assert "not configured" in result[0].text.lower() or "error" in result[0].text.lower()


### PR DESCRIPTION
## Summary

- Integrates crawled FortiMonitor WebGUI data (196 pages, 34,867 elements, 737 forms, 1,366 modals) as a read-only knowledge layer exposed through 7 new MCP tools (241 → 248 total)
- `SchemaStore` lazy-loads the 19MB JSON schema on first tool call and builds in-memory word-level indexes for fast querying across page titles, element labels, form fields, and modal titles
- `ui_get_screenshot` returns `ImageContent` (base64 PNG) alongside `TextContent` context, leveraging the MCP SDK's mixed content type support

### New Tools

| Tool | Purpose |
|------|---------|
| `ui_list_pages` | Browse crawled pages with category filter + pagination |
| `ui_get_page` | Full page details (sections, forms, modals, links) |
| `ui_search` | Word-level search across titles/elements/forms/modals |
| `ui_get_screenshot` | Page screenshot as base64 PNG image |
| `ui_get_navigation` | Hierarchical navigation tree from URL paths |
| `ui_describe_page` | Human-readable markdown page description |
| `ui_get_form` | Detailed form/field info from page + modal forms |

### Files Changed

- **New:** `src/webgui/__init__.py`, `src/webgui/store.py`, `src/webgui/tools.py`
- **Modified:** `src/config.py` (2 new settings), `src/server.py` (import + register + configure)
- **Tests:** `tests/test_webgui_tools.py` (52 new tests), `tests/test_registry.py` (updated count to 248)

## Test plan

- [x] `pytest tests/test_webgui_tools.py -v` — 52 new tests pass (tool definitions, SchemaStore unit tests, async handler tests, unconfigured store error handling)
- [x] `pytest tests/test_registry.py -v` — registry expects 248 tools
- [x] `pytest tests/ -v` — full suite passes (263 passed, 3 skipped, 0 failures)
- [ ] Manual smoke test with real crawl data: `ui_list_pages`, `ui_search`, `ui_get_screenshot`, `ui_describe_page`

🤖 Generated with [Claude Code](https://claude.com/claude-code)