### PR TITLE
Add WebGUI walkthroughs & extract into standalone MCP server

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,7 @@ dev = [
 
 [project.scripts]
 fortimonitor-mcp = "src.server:main"
+fortimonitor-webgui = "src.webgui.server:main"
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"

--- a/src/config.py
+++ b/src/config.py
@@ -77,20 +77,6 @@ class Settings(BaseSettings):
         description="Path to the YAML file defining documentation sources",
     )
 
-    # WebGUI Knowledge Layer Configuration
-    webgui_schema_file: Path = Field(
-        default=Path("data/schemas/crawl-31e23c1bfdd1.json"),
-        description="Path to the WebGUI crawl schema JSON file",
-    )
-    webgui_screenshots_dir: Path = Field(
-        default=Path("data/crawl-31e23c1bfdd1"),
-        description="Directory containing WebGUI page screenshots",
-    )
-    webgui_workflows_file: Path = Field(
-        default=Path("data/workflows.yaml"),
-        description="Path to the WebGUI workflow definitions YAML file",
-    )
-
     @property
     def api_base_url(self) -> str:
         """Get API base URL as string."""

--- a/src/server.py
+++ b/src/server.py
@@ -238,13 +238,6 @@ from .knowledge.tools.management import (
 )
 from .knowledge.tools.management import configure as configure_management
 
-# WebGUI Knowledge Layer tools
-from .webgui.tools import (
-    WEBGUI_TOOL_DEFINITIONS,
-    WEBGUI_HANDLERS,
-)
-from .webgui.tools import configure as configure_webgui
-
 # Get settings
 _settings = get_settings()
 
@@ -358,8 +351,6 @@ def _build_registry():
         (KNOWLEDGE_SEARCH_TOOL_DEFINITIONS, KNOWLEDGE_SEARCH_HANDLERS),
         (KNOWLEDGE_RETRIEVAL_TOOL_DEFINITIONS, KNOWLEDGE_RETRIEVAL_HANDLERS),
         (KNOWLEDGE_MANAGEMENT_TOOL_DEFINITIONS, KNOWLEDGE_MANAGEMENT_HANDLERS),
-        # WebGUI Knowledge Layer tools
-        (WEBGUI_TOOL_DEFINITIONS, WEBGUI_HANDLERS),
     ]:
         for name, defn_func in defn_dict.items():
             tool = defn_func()
@@ -393,23 +384,6 @@ class FortiMonitorMCPServer:
             sources_file=kb_sources,
             embedding_model=kb_model,
         )
-
-        # Configure WebGUI Knowledge Layer
-        webgui_schema = Path(_settings.webgui_schema_file)
-        webgui_screenshots = Path(_settings.webgui_screenshots_dir)
-        webgui_workflows = Path(_settings.webgui_workflows_file)
-        if webgui_schema.exists():
-            configure_webgui(
-                schema_file=webgui_schema,
-                screenshots_dir=webgui_screenshots,
-                workflows_file=webgui_workflows,
-            )
-        else:
-            logger.warning(
-                "WebGUI schema file not found at %s — WebGUI tools will "
-                "return errors until the schema is available.",
-                webgui_schema,
-            )
 
         logger.info(
             f"Initialized {_settings.mcp_server_name} v{_settings.mcp_server_version} "

--- a/src/webgui/server.py
+++ b/src/webgui/server.py
@@ -1,0 +1,169 @@
+"""Standalone MCP server for FortiMonitor WebGUI knowledge tools.
+
+Exposes the 10 WebGUI tools (page listings, search, screenshots, navigation,
+walkthroughs, cropping) as an independent MCP server.  No FortiMonitor API
+client is needed — all data comes from static crawl artifacts.
+
+Configuration via environment variables (with defaults matching the main
+server's former config):
+
+    WEBGUI_SCHEMA_FILE      — path to crawl schema JSON
+    WEBGUI_SCREENSHOTS_DIR  — directory containing page screenshots
+    WEBGUI_WORKFLOWS_FILE   — path to workflow definitions YAML
+    LOG_LEVEL               — logging level (default: INFO)
+"""
+
+import asyncio
+import logging
+import os
+from pathlib import Path
+from typing import Any, List
+
+from mcp.server import Server
+from mcp.server.models import InitializationOptions
+from mcp.server.stdio import stdio_server
+from mcp.types import ServerCapabilities, TextContent, Tool, ToolsCapability
+
+from .tools import (
+    WEBGUI_HANDLERS,
+    WEBGUI_TOOL_DEFINITIONS,
+    configure as configure_webgui,
+)
+
+_SERVER_NAME = "fortimonitor-webgui"
+_SERVER_VERSION = "1.0.0"
+
+# Defaults mirror the values formerly in src/config.py
+_DEFAULT_SCHEMA_FILE = "data/schemas/crawl-31e23c1bfdd1.json"
+_DEFAULT_SCREENSHOTS_DIR = "data/crawl-31e23c1bfdd1"
+_DEFAULT_WORKFLOWS_FILE = "data/workflows.yaml"
+
+# ---------------------------------------------------------------------------
+# Logging
+# ---------------------------------------------------------------------------
+
+_log_level = os.environ.get("LOG_LEVEL", "INFO").upper()
+logging.basicConfig(
+    level=getattr(logging, _log_level, logging.INFO),
+    format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+)
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Tool registry (built once at module level)
+# ---------------------------------------------------------------------------
+
+def _build_registry():
+    """Build tool definitions and handler map from the WebGUI module."""
+    tool_definitions: List[Tool] = []
+    handler_map = {}
+
+    for name, defn_func in WEBGUI_TOOL_DEFINITIONS.items():
+        tool = defn_func()
+        tool_definitions.append(tool)
+        handler_map[name] = WEBGUI_HANDLERS[name]
+
+    return tool_definitions, handler_map
+
+
+_TOOL_DEFINITIONS, _HANDLER_MAP = _build_registry()
+
+
+# ---------------------------------------------------------------------------
+# Server
+# ---------------------------------------------------------------------------
+
+class WebGUIMCPServer:
+    """Standalone MCP server for FortiMonitor WebGUI knowledge tools."""
+
+    def __init__(self):
+        self.server = Server(_SERVER_NAME)
+        self._setup_handlers()
+        self._configure_stores()
+
+        logger.info(
+            "Initialized %s v%s with %d tools",
+            _SERVER_NAME,
+            _SERVER_VERSION,
+            len(_TOOL_DEFINITIONS),
+        )
+
+    def _configure_stores(self):
+        """Load schema / screenshot / workflow paths from environment."""
+        schema_file = Path(
+            os.environ.get("WEBGUI_SCHEMA_FILE", _DEFAULT_SCHEMA_FILE)
+        )
+        screenshots_dir = Path(
+            os.environ.get("WEBGUI_SCREENSHOTS_DIR", _DEFAULT_SCREENSHOTS_DIR)
+        )
+        workflows_file = Path(
+            os.environ.get("WEBGUI_WORKFLOWS_FILE", _DEFAULT_WORKFLOWS_FILE)
+        )
+
+        if schema_file.exists():
+            configure_webgui(
+                schema_file=schema_file,
+                screenshots_dir=screenshots_dir,
+                workflows_file=workflows_file,
+            )
+        else:
+            logger.warning(
+                "WebGUI schema file not found at %s — tools will return "
+                "errors until the schema is available.",
+                schema_file,
+            )
+
+    def _setup_handlers(self):
+        """Register MCP protocol handlers."""
+
+        @self.server.list_tools()
+        async def list_tools() -> List[Tool]:
+            return _TOOL_DEFINITIONS
+
+        @self.server.call_tool()
+        async def call_tool(name: str, arguments: Any) -> list:
+            logger.info("Tool called: %s", name)
+
+            handler = _HANDLER_MAP.get(name)
+            if handler:
+                # WebGUI tools never use the FortiMonitor client
+                return await handler(arguments, None)
+
+            raise ValueError(f"Unknown tool: {name}")
+
+    async def run(self):
+        """Run the MCP server over stdio."""
+        logger.info("Starting %s MCP server...", _SERVER_NAME)
+
+        try:
+            async with stdio_server() as (read_stream, write_stream):
+                capabilities = ServerCapabilities(
+                    tools=ToolsCapability(listChanged=False)
+                )
+                await self.server.run(
+                    read_stream,
+                    write_stream,
+                    InitializationOptions(
+                        server_name=_SERVER_NAME,
+                        server_version=_SERVER_VERSION,
+                        capabilities=capabilities,
+                    ),
+                )
+        except KeyboardInterrupt:
+            logger.info("Server stopped by user")
+        except Exception:
+            logger.exception("Server error")
+            raise
+        finally:
+            logger.info("%s MCP server stopped", _SERVER_NAME)
+
+
+def main():
+    """Entry point for the fortimonitor-webgui console script."""
+    server = WebGUIMCPServer()
+    asyncio.run(server.run())
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_webgui_server.py
+++ b/tests/test_webgui_server.py
@@ -1,0 +1,84 @@
+"""Smoke tests for the standalone WebGUI MCP server entry point."""
+
+import os
+import sys
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+
+class TestWebGUIServerRegistry:
+    """Verify the standalone server builds its registry correctly."""
+
+    def test_tool_definitions_count(self):
+        from src.webgui.server import _TOOL_DEFINITIONS
+
+        assert len(_TOOL_DEFINITIONS) == 10
+
+    def test_handler_map_count(self):
+        from src.webgui.server import _HANDLER_MAP
+
+        assert len(_HANDLER_MAP) == 10
+
+    def test_all_tools_have_handlers(self):
+        from src.webgui.server import _TOOL_DEFINITIONS, _HANDLER_MAP
+
+        tool_names = {t.name for t in _TOOL_DEFINITIONS}
+        handler_names = set(_HANDLER_MAP.keys())
+        assert tool_names == handler_names
+
+    def test_expected_tool_names(self):
+        from src.webgui.server import _TOOL_DEFINITIONS
+
+        names = {t.name for t in _TOOL_DEFINITIONS}
+        expected = {
+            "ui_list_pages",
+            "ui_get_page",
+            "ui_search",
+            "ui_get_screenshot",
+            "ui_get_navigation",
+            "ui_describe_page",
+            "ui_get_form",
+            "ui_list_walkthroughs",
+            "ui_get_walkthrough",
+            "ui_crop_screenshot",
+        }
+        assert names == expected
+
+    def test_server_instantiates(self):
+        """WebGUIMCPServer can be created (schema file missing is OK — it warns)."""
+        from src.webgui.server import WebGUIMCPServer
+
+        server = WebGUIMCPServer()
+        assert server.server is not None
+
+
+class TestMainServerExcludesWebGUI:
+    """Verify the main server no longer includes WebGUI tools."""
+
+    def test_no_webgui_tools_in_main_registry(self):
+        from src.server import _TOOL_DEFINITIONS
+
+        names = {t.name for t in _TOOL_DEFINITIONS}
+        webgui_names = {
+            "ui_list_pages",
+            "ui_get_page",
+            "ui_search",
+            "ui_get_screenshot",
+            "ui_get_navigation",
+            "ui_describe_page",
+            "ui_get_form",
+            "ui_list_walkthroughs",
+            "ui_get_walkthrough",
+            "ui_crop_screenshot",
+        }
+        assert names.isdisjoint(webgui_names), (
+            f"Main server still contains WebGUI tools: {names & webgui_names}"
+        )
+
+    def test_main_server_tool_count(self):
+        from src.server import _TOOL_DEFINITIONS
+
+        assert len(_TOOL_DEFINITIONS) == 249, (
+            f"Expected 249 tools in main server, got {len(_TOOL_DEFINITIONS)}"
+        )


### PR DESCRIPTION
## Summary

- **WebGUI walkthrough tools** — 3 new tools (`ui_list_walkthroughs`, `ui_get_walkthrough`, `ui_crop_screenshot`) providing step-by-step task guides for common FortiMonitor workflows (schedule maintenance, investigate incidents, configure alert timelines)
- **WorkflowStore** with YAML-defined walkthroughs enriched from SchemaStore (page titles, URLs, screenshots, highlight element positions)
- **Standalone WebGUI MCP server** — extracts all 10 WebGUI tools into a separate `fortimonitor-webgui` entry point so they only load when explicitly configured, keeping the main server lean at 249 tools
- **Validation script** (`scripts/validate_walkthroughs.py`) verifying walkthroughs against real crawl data

## Test plan

- [x] 99 WebGUI tests pass (7 new server smoke tests + 62 existing tools + 30 walkthrough tests)
- [x] Main server has 249 tools, no WebGUI tool names present
- [x] WebGUI server has 10 tools with correct names and handlers
- [x] `validate_walkthroughs.py` passes against real crawl data
- [ ] Verify `fortimonitor-webgui` entry point works in Claude Desktop config

🤖 Generated with [Claude Code](https://claude.com/claude-code)